### PR TITLE
機能(database,task): swap table時にCOUNT(*)による正確な行数比較を実装

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -747,12 +747,12 @@ func (m *Manager) checkNewTableExists(taskName, tableName string) error {
 }
 
 func (m *Manager) checkRowCountDifference(tableName string) error {
-	originalCount, err := m.db.GetTableRowCount(tableName)
+	originalCount, err := m.db.GetTableRowCountForSwap(tableName)
 	if err != nil {
 		return fmt.Errorf("failed to get original table row count: %w", err)
 	}
 
-	newCount, err := m.db.GetNewTableRowCount(tableName)
+	newCount, err := m.db.GetNewTableRowCountForSwap(tableName)
 	if err != nil {
 		return fmt.Errorf("failed to get new table row count: %w", err)
 	}


### PR DESCRIPTION
- database.Clientインターフェースに新しいメソッドを追加
  - GetTableRowCountForSwap: swap時の正確な行数取得用
  - GetNewTableRowCountForSwap: 新テーブルの正確な行数取得用
- MySQLClient実装でCOUNT(*)を常に使用する専用メソッドを追加
- manager.goのcheckRowCountDifferenceで新しいメソッドを使用
- 関連するテストケースを更新し、新しいメソッドに対応
- 通常のpt-osc処理では引き続き最適化された行数取得を使用