### PR TITLE
feat: pt-oscのno-check-alterパラメータに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pt_osc:
   no_drop_new_table: false
   no_drop_old_table: false
   no_check_unique_key_change: false
+  no_check_alter: false
 
 pt_osc_threshold: 1000000
 
@@ -117,6 +118,7 @@ buffer_pool_size_threshold_mb: 100.0
 | `no_drop_new_table`         | bool    | false   | Do not drop new table on failure                                                   |
 | `no_drop_old_table`         | bool    | false   | Do not drop old table after swap                                                   |
 | `no_check_unique_key_change`| bool    | false   | Disable unique key change check. When true, pt-osc can run even if the ALTER adds a unique index (bypasses pt-osc default safety check) |
+| `no_check_alter`            | bool    | false   | Disable ALTER statement validation. When true, pt-osc can run even if the ALTER contains potentially unsafe operations like column renames (bypasses pt-osc default safety check) |
 
 #### Global Settings
 
@@ -297,6 +299,7 @@ data:
       statistics: true
       dry_run: false
       no_check_unique_key_change: false
+      no_check_alter: false
 
     pt_osc_threshold: 1000000
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ type PtOscConfig struct {
 	NoDropNewTable         bool    `yaml:"no_drop_new_table"`
 	NoDropOldTable         bool    `yaml:"no_drop_old_table"`
 	NoCheckUniqueKeyChange bool    `yaml:"no_check_unique_key_change"`
+	NoCheckAlter           bool    `yaml:"no_check_alter"`
 }
 
 type PtArchiverConfig struct {

--- a/internal/ptosc/executor.go
+++ b/internal/ptosc/executor.go
@@ -288,6 +288,10 @@ func (e *PtOscExecutor) BuildArgsWithPassword(
 		args = append(args, "--no-check-unique-key-change")
 	}
 
+	if ptOscConfig.NoCheckAlter {
+		args = append(args, "--no-check-alter")
+	}
+
 	if forceDryRun || ptOscConfig.DryRun {
 		args = append(args, "--dry-run")
 	} else {

--- a/internal/ptosc/executor_test.go
+++ b/internal/ptosc/executor_test.go
@@ -201,6 +201,41 @@ func TestBuildArgsWithPassword(t *testing.T) {
 			},
 			expectedPassword: "pass",
 		},
+		{
+			name:           "no-check-alter enabled",
+			tableName:      "users",
+			alterStatement: "CHANGE COLUMN old_name new_name VARCHAR(255)",
+			ptOscConfig: config.PtOscConfig{
+				NoCheckAlter: true,
+			},
+			dsn:         "user:pass@tcp(localhost:3306)/testdb",
+			forceDryRun: false,
+			expectedArgs: []string{
+				"--alter=CHANGE COLUMN old_name new_name VARCHAR(255)",
+				"--ask-pass",
+				"--no-check-alter",
+				"--execute",
+				"h=localhost,P=3306,D=testdb,t=users,u=user",
+			},
+			expectedPassword: "pass",
+		},
+		{
+			name:           "no-check-alter disabled (default behavior)",
+			tableName:      "users",
+			alterStatement: "CHANGE COLUMN old_name new_name VARCHAR(255)",
+			ptOscConfig: config.PtOscConfig{
+				NoCheckAlter: false,
+			},
+			dsn:         "user:pass@tcp(localhost:3306)/testdb",
+			forceDryRun: false,
+			expectedArgs: []string{
+				"--alter=CHANGE COLUMN old_name new_name VARCHAR(255)",
+				"--ask-pass",
+				"--execute",
+				"h=localhost,P=3306,D=testdb,t=users,u=user",
+			},
+			expectedPassword: "pass",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要
カラムのリネームなどを含むALTER文を実行する際に、pt-online-schema-changeが出すエラーを回避するため、`--no-check-alter`オプションをサポートしました。

## 背景
pt-online-schema-changeでカラムのリネームを含むALTER文を実行すると、以下のエラーが発生します：
```
The tool should handle this correctly, but you should test it first because if it fails the renamed columns' data will be lost! Specify --no-check-alter to disable this check and perform the --alter.
```

このエラーを回避するため、`--no-check-alter`オプションを設定できるようにしました。

## 変更内容
- `PtOscConfig`に`NoCheckAlter`フィールドを追加
- `BuildArgsWithPassword`メソッドに`--no-check-alter`オプションを追加
- README.mdに新しいオプションの説明を追加
- ユニットテストを追加（`no_check_alter`有効/無効のテストケース）

## 使用方法
`config-common.yaml`に以下を設定することで有効化できます：
```yaml
pt_osc:
  no_check_alter: true
```

## テスト
- ✅ すべてのユニットテストが通過
- ✅ ビルドが成功

## 注意事項
`no_check_alter: true`を設定すると、データ損失のリスクがある操作（カラムのリネームなど）のチェックが無効になります。必ず事前にテストを行ってから本番環境で使用してください。