### PR TITLE
feat: ALTER文を受け取った順番通りに実行し、全体の実行状況をSlack通知

### DIFF
--- a/internal/slack/notifier.go
+++ b/internal/slack/notifier.go
@@ -26,6 +26,9 @@ type Notifier interface {
 	NotifyTriggerCleanupSuccess(taskName, tableName string, triggers []string, duration time.Duration) error
 	NotifyTriggerCleanupFailure(taskName, tableName string, triggers []string, err error) error
 	NotifyPtOscPreCheckFailure(taskName, tableName string) error
+	NotifyAllTasksStart(totalQueries int) error
+	NotifyAllTasksSuccess(totalQueries int, duration time.Duration) error
+	NotifyAllTasksFailure(totalQueries int, err error) error
 }
 
 type DryRunResult struct {
@@ -228,6 +231,27 @@ func (n *SlackNotifier) NotifyPtOscPreCheckFailure(taskName, tableName string) e
 		title, taskName, tableName, tableName, tableName)
 
 	return n.sendMessage(message, "warning")
+}
+
+func (n *SlackNotifier) NotifyAllTasksStart(totalQueries int) error {
+	title := n.formatTitle("🚀 All tasks started")
+	message := fmt.Sprintf("%s\nTotal queries: %d", title, totalQueries)
+
+	return n.sendMessage(message, "good")
+}
+
+func (n *SlackNotifier) NotifyAllTasksSuccess(totalQueries int, duration time.Duration) error {
+	title := n.formatTitle("✅ All tasks completed successfully")
+	message := fmt.Sprintf("%s\nTotal queries: %d\nTotal duration: %s", title, totalQueries, duration.String())
+
+	return n.sendMessage(message, "good")
+}
+
+func (n *SlackNotifier) NotifyAllTasksFailure(totalQueries int, err error) error {
+	title := n.formatTitle("❌ Tasks failed")
+	message := fmt.Sprintf("%s\nTotal queries: %d\nError: %s", title, totalQueries, err.Error())
+
+	return n.sendMessage(message, "danger")
 }
 
 func (n *SlackNotifier) sendMessage(text, color string) error {


### PR DESCRIPTION
## 概要
ALTER文を受け取った順番通りに実行するように変更し、全体のタスク実行状況をSlack通知する機能を追加しました。

## 変更内容

### 1. クエリ実行順序の改善
- **テーブルごとのグループ化を廃止**
  - `TableGroup`構造体および関連する関数を削除
  - Go mapの非決定的な反復順序の問題を解決
- **順次実行への変更**
  - `ExecuteAllTasks()`を書き換え、受け取った順番通りにクエリを1つずつ実行
  - ALTER TABLEでテーブル名が変わるケース（RENAME TABLE等）に対応
- **新しいヘルパー関数の追加**
  - `executeSingleQuery()`: 適切な実行メソッドにルーティング
  - `executeAlterQuery()`: 直接ALTERかpt-oscかを判断
  - `executeAlterTableDirect()`: 小規模なALTERを直接実行
  - `executeAlterTableWithPtOsc()`: 大規模なALTERをpt-oscで実行
  - `executeSmallQuery()`: ALTER以外のクエリを実行

### 2. Slack通知機能の追加
- **全体のタスク実行状況を通知**
  - `NotifyAllTasksStart(totalQueries int)`: 開始時に総クエリ数を通知
  - `NotifyAllTasksSuccess(totalQueries int, duration time.Duration)`: 完了時に総クエリ数と実行時間を通知
  - `NotifyAllTasksFailure(totalQueries int, err error)`: 失敗時に総クエリ数とエラーを通知

### 3. テストの更新
- すべてのテストケースに新しいSlack通知のモック設定を追加
- `TestExecutionOrder`で順次実行を検証
- すべてのテストが通過することを確認

## テスト結果
```
PASS
ok  	github.com/pyama86/alterguard/internal/task	4.543s
```

## Linter結果
```
0 issues.
```

## 影響範囲
- `internal/task/manager.go`: クエリ実行ロジックの大幅な変更
- `internal/slack/notifier.go`: 新しい通知メソッドの追加
- `internal/task/manager_test.go`: テストケースの更新

## 動作確認
- [ ] 複数のALTER文が順番通りに実行されることを確認
- [ ] 全体の開始・完了時にSlack通知が送信されることを確認
- [ ] エラー発生時にSlack通知が送信されることを確認