### PR TITLE
feat: Aurora MySQLのreader遅延に応じてpt-oscをpause-fileで抑制

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ pt_osc:
   no_drop_old_table: false
   no_check_unique_key_change: false
   no_check_alter: false
+  aurora_replica_check:
+    enabled: false
+    max_lag_ms: 1000
+    check_interval: 5s
+    pause_file_path: /tmp/alterguard-ptosc-pause
 
 pt_osc_threshold: 1000000
 
@@ -119,6 +124,25 @@ buffer_pool_size_threshold_mb: 100.0
 | `no_drop_old_table`         | bool    | false   | Do not drop old table after swap                                                   |
 | `no_check_unique_key_change`| bool    | false   | Disable unique key change check. When true, pt-osc can run even if the ALTER adds a unique index (bypasses pt-osc default safety check) |
 | `no_check_alter`            | bool    | false   | Disable ALTER statement validation. When true, pt-osc can run even if the ALTER contains potentially unsafe operations like column renames (bypasses pt-osc default safety check) |
+| `aurora_replica_check`      | object  | -       | Aurora reader replica lag monitor (see below) |
+
+#### Aurora Replica Check Section (`pt_osc.aurora_replica_check`)
+
+For Amazon Aurora MySQL clusters, pt-osc's standard `recursion_method` cannot observe reader lag. When enabled, alterguard polls `information_schema.REPLICA_HOST_STATUS` while pt-osc runs; if the maximum reader lag exceeds `max_lag_ms`, alterguard writes the pause file passed to pt-osc as `--pause-file`, which automatically suspends pt-osc until the lag recovers and the file is removed.
+
+| Option            | Type    | Default                          | Description                                                                              |
+| ----------------- | ------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `enabled`         | bool    | false                            | Enable Aurora reader lag monitoring                                                      |
+| `max_lag_ms`      | float64 | 0                                | Lag threshold in milliseconds. Above this value the pause file is created                |
+| `check_interval`  | string  | 5s                               | Poll interval (Go duration string, e.g. `1s`, `500ms`)                                   |
+| `pause_file_path` | string  | `/tmp/alterguard-ptosc-pause`    | Pause file location passed to pt-osc                                                     |
+
+When enabled, alterguard performs a preflight before launching pt-osc:
+
+1. Creates and removes the pause file to verify filesystem permissions.
+2. Issues a `SELECT` against `information_schema.REPLICA_HOST_STATUS` to verify read permissions.
+
+If either check fails, pt-osc is **not** started and an error is returned. The required MySQL privileges are described in the *Aurora support* section below.
 
 #### Global Settings
 
@@ -381,6 +405,24 @@ echo "SLACK_WEBHOOK_URL=https://hooks.slack.com/services/..." >> .env
 # Run with stdin input
 echo "ALTER TABLE test ADD COLUMN new_col INT;" | ./alterguard run --common-config examples/config-common.yaml --stdin
 ```
+
+## Aurora Support
+
+When running against an Amazon Aurora MySQL cluster, enable `pt_osc.aurora_replica_check` to throttle pt-osc based on reader replica lag observed in `information_schema.REPLICA_HOST_STATUS`.
+
+### Required MySQL Privileges
+
+The user specified in `DATABASE_DSN` must be able to read `information_schema.REPLICA_HOST_STATUS`. In Aurora this view is exposed via the standard `SELECT` privilege on `information_schema` (already implicit for any authenticated user), but make sure that the role used has not been further restricted, e.g.:
+
+```sql
+GRANT SELECT ON `information_schema`.* TO 'alterguard'@'%';
+```
+
+The other privileges already required by pt-osc and alterguard remain unchanged (`ALTER`, `CREATE`, `DROP`, `INSERT`, `UPDATE`, `DELETE`, `INDEX`, `LOCK TABLES`, `TRIGGER`, `PROCESS`, `REPLICATION CLIENT`).
+
+### Required OS Permissions
+
+The process running alterguard must be able to create and remove files at `pause_file_path`. The default `/tmp/alterguard-ptosc-pause` works for most setups; in Kubernetes ensure the path is writable (`emptyDir` volume mount, or default writable filesystem).
 
 ## License
 

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -70,7 +70,7 @@ func cleanupTable(tableName string) error {
 	logger.Info("Database connection established")
 
 	// Initialize pt-osc executor (not used for cleanup but required for manager)
-	ptoscExecutor := ptosc.NewPtOscExecutor(logger)
+	ptoscExecutor := ptosc.NewPtOscExecutor(logger, dbClient)
 
 	// Initialize pt-archiver executor (used for cleanup if enabled)
 	ptarchiverExecutor := ptarchiver.NewPtArchiverExecutor(logger)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -85,7 +85,7 @@ func runTasks() error {
 	logger.Info("Database connection established")
 
 	// Initialize pt-osc executor
-	ptoscExecutor := ptosc.NewPtOscExecutor(logger)
+	ptoscExecutor := ptosc.NewPtOscExecutor(logger, dbClient)
 
 	// Initialize pt-archiver executor
 	ptarchiverExecutor := ptarchiver.NewPtArchiverExecutor(logger)

--- a/cmd/swap.go
+++ b/cmd/swap.go
@@ -57,7 +57,7 @@ func swapTable(tableName string) error {
 	logger.Info("Database connection established")
 
 	// Initialize pt-osc executor (not used for swap but required for manager)
-	ptoscExecutor := ptosc.NewPtOscExecutor(logger)
+	ptoscExecutor := ptosc.NewPtOscExecutor(logger, dbClient)
 
 	// Initialize pt-archiver executor (not used for swap but required for manager)
 	ptarchiverExecutor := ptarchiver.NewPtArchiverExecutor(logger)

--- a/examples/config-common.yaml
+++ b/examples/config-common.yaml
@@ -7,6 +7,12 @@ pt_osc:
   statistics: true
   dry_run: false
   # no_check_unique_key_change: false  # Disable unique key change check (default: false)
+  # Aurora MySQL では recursion_method がレプリカ遅延を検出できないため、information_schema.REPLICA_HOST_STATUS を見て pause-file で抑制する。
+  # aurora_replica_check:
+  #   enabled: true
+  #   max_lag_ms: 1000
+  #   check_interval: 5s
+  #   pause_file_path: /tmp/alterguard-ptosc-pause
 
 pt_osc_threshold: 1000
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,18 +22,26 @@ type CommonConfig struct {
 }
 
 type PtOscConfig struct {
-	Charset                string  `yaml:"charset"`
-	RecursionMethod        string  `yaml:"recursion_method"`
-	NoSwapTables           bool    `yaml:"no_swap_tables"`
-	ChunkSize              int     `yaml:"chunk_size"`
-	MaxLag                 float64 `yaml:"max_lag"`
-	Statistics             bool    `yaml:"statistics"`
-	DryRun                 bool    `yaml:"dry_run"`
-	NoDropTriggers         bool    `yaml:"no_drop_triggers"`
-	NoDropNewTable         bool    `yaml:"no_drop_new_table"`
-	NoDropOldTable         bool    `yaml:"no_drop_old_table"`
-	NoCheckUniqueKeyChange bool    `yaml:"no_check_unique_key_change"`
-	NoCheckAlter           bool    `yaml:"no_check_alter"`
+	Charset                string                   `yaml:"charset"`
+	RecursionMethod        string                   `yaml:"recursion_method"`
+	NoSwapTables           bool                     `yaml:"no_swap_tables"`
+	ChunkSize              int                      `yaml:"chunk_size"`
+	MaxLag                 float64                  `yaml:"max_lag"`
+	Statistics             bool                     `yaml:"statistics"`
+	DryRun                 bool                     `yaml:"dry_run"`
+	NoDropTriggers         bool                     `yaml:"no_drop_triggers"`
+	NoDropNewTable         bool                     `yaml:"no_drop_new_table"`
+	NoDropOldTable         bool                     `yaml:"no_drop_old_table"`
+	NoCheckUniqueKeyChange bool                     `yaml:"no_check_unique_key_change"`
+	NoCheckAlter           bool                     `yaml:"no_check_alter"`
+	AuroraReplicaCheck     AuroraReplicaCheckConfig `yaml:"aurora_replica_check"`
+}
+
+type AuroraReplicaCheckConfig struct {
+	Enabled       bool    `yaml:"enabled"`
+	MaxLagMs      float64 `yaml:"max_lag_ms"`
+	CheckInterval string  `yaml:"check_interval"`
+	PauseFilePath string  `yaml:"pause_file_path"`
 }
 
 type PtArchiverConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -181,6 +181,68 @@ disable_analyze_table: false
 	}
 }
 
+func TestAuroraReplicaCheckConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		yamlData          string
+		wantEnabled       bool
+		wantMaxLagMs      float64
+		wantCheckInterval string
+		wantPauseFilePath string
+	}{
+		{
+			name: "aurora_replica_check not specified - defaults",
+			yamlData: `
+pt_osc:
+  charset: utf8mb4
+`,
+			wantEnabled:       false,
+			wantMaxLagMs:      0,
+			wantCheckInterval: "",
+			wantPauseFilePath: "",
+		},
+		{
+			name: "aurora_replica_check fully specified",
+			yamlData: `
+pt_osc:
+  aurora_replica_check:
+    enabled: true
+    max_lag_ms: 1500
+    check_interval: 10s
+    pause_file_path: /tmp/alterguard-ptosc-pause
+`,
+			wantEnabled:       true,
+			wantMaxLagMs:      1500,
+			wantCheckInterval: "10s",
+			wantPauseFilePath: "/tmp/alterguard-ptosc-pause",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &CommonConfig{}
+			err := yaml.Unmarshal([]byte(tt.yamlData), config)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal YAML: %v", err)
+			}
+
+			got := config.PtOsc.AuroraReplicaCheck
+			if got.Enabled != tt.wantEnabled {
+				t.Errorf("Enabled = %v, want %v", got.Enabled, tt.wantEnabled)
+			}
+			if got.MaxLagMs != tt.wantMaxLagMs {
+				t.Errorf("MaxLagMs = %v, want %v", got.MaxLagMs, tt.wantMaxLagMs)
+			}
+			if got.CheckInterval != tt.wantCheckInterval {
+				t.Errorf("CheckInterval = %v, want %v", got.CheckInterval, tt.wantCheckInterval)
+			}
+			if got.PauseFilePath != tt.wantPauseFilePath {
+				t.Errorf("PauseFilePath = %v, want %v", got.PauseFilePath, tt.wantPauseFilePath)
+			}
+		})
+	}
+}
+
 func TestNoCheckUniqueKeyChange(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/database/client.go
+++ b/internal/database/client.go
@@ -25,6 +25,7 @@ type Client interface {
 	GetCurrentUser() (string, error)
 	AnalyzeTable(tableName string) error
 	GetTableBufferPoolSizeMB(schemaName, tableName string) (float64, error)
+	GetMaxAuroraReplicaLagMs() (float64, error)
 	Close() error
 }
 
@@ -307,6 +308,26 @@ func (c *MySQLClient) GetTableBufferPoolSizeMB(schemaName, tableName string) (fl
 
 	c.logger.Infof("Buffer pool size for table %s: %.2f MB", fullTableName, sizeMB)
 	return sizeMB, nil
+}
+
+func (c *MySQLClient) GetMaxAuroraReplicaLagMs() (float64, error) {
+	var lagMs sql.NullFloat64
+
+	query := `
+		SELECT MAX(replica_lag_in_milliseconds)
+		FROM information_schema.REPLICA_HOST_STATUS
+		WHERE session_id <> 'MASTER_SESSION_ID'
+	`
+
+	err := c.db.Get(&lagMs, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to query REPLICA_HOST_STATUS: %w", err)
+	}
+
+	if !lagMs.Valid {
+		return 0, nil
+	}
+	return lagMs.Float64, nil
 }
 
 func (c *MySQLClient) Close() error {

--- a/internal/ptosc/aurora_monitor.go
+++ b/internal/ptosc/aurora_monitor.go
@@ -1,0 +1,181 @@
+package ptosc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/pyama86/alterguard/internal/config"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	defaultAuroraCheckInterval = 5 * time.Second
+	defaultAuroraPauseFilePath = "/tmp/alterguard-ptosc-pause"
+)
+
+type ReplicaLagFetcher interface {
+	GetMaxAuroraReplicaLagMs() (float64, error)
+}
+
+type AuroraMonitor struct {
+	cfg           config.AuroraReplicaCheckConfig
+	fetcher       ReplicaLagFetcher
+	logger        *logrus.Logger
+	checkInterval time.Duration
+	pauseFilePath string
+
+	mu             sync.Mutex
+	pauseFileOwned bool
+}
+
+func NewAuroraMonitor(cfg config.AuroraReplicaCheckConfig, fetcher ReplicaLagFetcher, logger *logrus.Logger) (*AuroraMonitor, error) {
+	interval, err := resolveCheckInterval(cfg.CheckInterval)
+	if err != nil {
+		return nil, fmt.Errorf("invalid aurora_replica_check.check_interval: %w", err)
+	}
+
+	pauseFilePath := cfg.PauseFilePath
+	if pauseFilePath == "" {
+		pauseFilePath = defaultAuroraPauseFilePath
+	}
+
+	return &AuroraMonitor{
+		cfg:           cfg,
+		fetcher:       fetcher,
+		logger:        logger,
+		checkInterval: interval,
+		pauseFilePath: pauseFilePath,
+	}, nil
+}
+
+func (m *AuroraMonitor) PauseFilePath() string {
+	return m.pauseFilePath
+}
+
+// pause-fileの作成/削除と REPLICA_HOST_STATUS の読取が可能か事前確認する。失敗時は実行を止めるべきというシグナル。
+func (m *AuroraMonitor) Preflight() error {
+	tmp, err := os.Create(m.pauseFilePath) // #nosec G304
+	if err != nil {
+		return fmt.Errorf("cannot create pause file %s: %w", m.pauseFilePath, err)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		_ = os.Remove(m.pauseFilePath)
+		return fmt.Errorf("cannot close pause file %s: %w", m.pauseFilePath, cerr)
+	}
+	if rerr := os.Remove(m.pauseFilePath); rerr != nil {
+		return fmt.Errorf("cannot remove pause file %s: %w", m.pauseFilePath, rerr)
+	}
+
+	if _, err := m.fetcher.GetMaxAuroraReplicaLagMs(); err != nil {
+		return fmt.Errorf("cannot read information_schema.REPLICA_HOST_STATUS: %w", err)
+	}
+	return nil
+}
+
+// 監視ループを開始。ctxがキャンセルされるかStopが呼ばれるまで動く。
+func (m *AuroraMonitor) Run(ctx context.Context) {
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
+
+	m.checkOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			m.cleanupPauseFile()
+			return
+		case <-ticker.C:
+			m.checkOnce(ctx)
+		}
+	}
+}
+
+func (m *AuroraMonitor) checkOnce(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	lagMs, err := m.fetcher.GetMaxAuroraReplicaLagMs()
+	if err != nil {
+		m.logger.Warnf("Aurora replica lag check failed: %v", err)
+		return
+	}
+
+	if lagMs > m.cfg.MaxLagMs {
+		m.logger.Warnf("Aurora replica lag %.2fms exceeds threshold %.2fms; creating pause file %s",
+			lagMs, m.cfg.MaxLagMs, m.pauseFilePath)
+		if err := m.createPauseFile(); err != nil {
+			m.logger.Errorf("Failed to create pause file %s: %v", m.pauseFilePath, err)
+		}
+		return
+	}
+
+	m.logger.Debugf("Aurora replica lag %.2fms within threshold %.2fms", lagMs, m.cfg.MaxLagMs)
+	if err := m.removePauseFileIfOwned(); err != nil {
+		m.logger.Warnf("Failed to remove pause file %s: %v", m.pauseFilePath, err)
+	}
+}
+
+func (m *AuroraMonitor) createPauseFile() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	f, err := os.OpenFile(m.pauseFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) // #nosec G304
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "paused at %s due to aurora replica lag\n", time.Now().Format(time.RFC3339)); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	m.pauseFileOwned = true
+	return nil
+}
+
+func (m *AuroraMonitor) removePauseFileIfOwned() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.pauseFileOwned {
+		return nil
+	}
+	if err := os.Remove(m.pauseFilePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	m.pauseFileOwned = false
+	m.logger.Infof("Aurora replica lag recovered; removed pause file %s", m.pauseFilePath)
+	return nil
+}
+
+func (m *AuroraMonitor) cleanupPauseFile() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.pauseFileOwned {
+		return
+	}
+	if err := os.Remove(m.pauseFilePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		m.logger.Warnf("Failed to remove pause file %s on shutdown: %v", m.pauseFilePath, err)
+		return
+	}
+	m.pauseFileOwned = false
+}
+
+func resolveCheckInterval(raw string) (time.Duration, error) {
+	if raw == "" {
+		return defaultAuroraCheckInterval, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("check_interval must be positive, got %s", raw)
+	}
+	return d, nil
+}

--- a/internal/ptosc/aurora_monitor_test.go
+++ b/internal/ptosc/aurora_monitor_test.go
@@ -1,0 +1,189 @@
+package ptosc
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pyama86/alterguard/internal/config"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeFetcher struct {
+	lagMs atomic.Value
+	err   atomic.Value
+	calls atomic.Int64
+}
+
+func newFakeFetcher(initialLag float64) *fakeFetcher {
+	f := &fakeFetcher{}
+	f.lagMs.Store(initialLag)
+	return f
+}
+
+func (f *fakeFetcher) setLag(v float64) {
+	f.lagMs.Store(v)
+}
+
+func (f *fakeFetcher) setErr(err error) {
+	if err == nil {
+		f.err.Store((*errWrap)(nil))
+		return
+	}
+	f.err.Store(&errWrap{err: err})
+}
+
+func (f *fakeFetcher) GetMaxAuroraReplicaLagMs() (float64, error) {
+	f.calls.Add(1)
+	if v := f.err.Load(); v != nil {
+		if w, ok := v.(*errWrap); ok && w != nil {
+			return 0, w.err
+		}
+	}
+	return f.lagMs.Load().(float64), nil
+}
+
+type errWrap struct{ err error }
+
+func TestAuroraMonitorPreflight(t *testing.T) {
+	t.Run("writable path passes", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := config.AuroraReplicaCheckConfig{
+			Enabled:       true,
+			MaxLagMs:      1000,
+			PauseFilePath: filepath.Join(dir, "pause"),
+		}
+		m, err := NewAuroraMonitor(cfg, newFakeFetcher(0), logrus.New())
+		require.NoError(t, err)
+
+		require.NoError(t, m.Preflight())
+		_, statErr := os.Stat(cfg.PauseFilePath)
+		assert.True(t, os.IsNotExist(statErr), "pause file should be cleaned up after preflight")
+	})
+
+	t.Run("unwritable path fails", func(t *testing.T) {
+		cfg := config.AuroraReplicaCheckConfig{
+			Enabled:       true,
+			MaxLagMs:      1000,
+			PauseFilePath: "/nonexistent-dir-for-alterguard/pause",
+		}
+		m, err := NewAuroraMonitor(cfg, newFakeFetcher(0), logrus.New())
+		require.NoError(t, err)
+		err = m.Preflight()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot create pause file")
+	})
+
+	t.Run("information_schema unreadable fails", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := config.AuroraReplicaCheckConfig{
+			Enabled:       true,
+			MaxLagMs:      1000,
+			PauseFilePath: filepath.Join(dir, "pause"),
+		}
+		fetcher := newFakeFetcher(0)
+		fetcher.setErr(errors.New("access denied"))
+
+		m, err := NewAuroraMonitor(cfg, fetcher, logrus.New())
+		require.NoError(t, err)
+
+		err = m.Preflight()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "information_schema.REPLICA_HOST_STATUS")
+	})
+}
+
+func TestAuroraMonitorRunCreatesAndRemovesPauseFile(t *testing.T) {
+	dir := t.TempDir()
+	pausePath := filepath.Join(dir, "pause")
+
+	fetcher := newFakeFetcher(2000) // 閾値超
+	cfg := config.AuroraReplicaCheckConfig{
+		Enabled:       true,
+		MaxLagMs:      1000,
+		CheckInterval: "20ms",
+		PauseFilePath: pausePath,
+	}
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+	m, err := NewAuroraMonitor(cfg, fetcher, logger)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(pausePath)
+		return err == nil
+	}, 1*time.Second, 10*time.Millisecond, "pause file should be created")
+
+	// 遅延を解消するとファイルが削除される
+	fetcher.setLag(100)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(pausePath)
+		return os.IsNotExist(err)
+	}, 1*time.Second, 10*time.Millisecond, "pause file should be removed when lag recovers")
+}
+
+func TestAuroraMonitorCleanupOnCancel(t *testing.T) {
+	dir := t.TempDir()
+	pausePath := filepath.Join(dir, "pause")
+
+	fetcher := newFakeFetcher(5000)
+	cfg := config.AuroraReplicaCheckConfig{
+		Enabled:       true,
+		MaxLagMs:      1000,
+		CheckInterval: "20ms",
+		PauseFilePath: pausePath,
+	}
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+	m, err := NewAuroraMonitor(cfg, fetcher, logger)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		m.Run(ctx)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(pausePath)
+		return err == nil
+	}, 1*time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+
+	_, err = os.Stat(pausePath)
+	assert.True(t, os.IsNotExist(err), "pause file should be cleaned up after cancel")
+}
+
+func TestResolveCheckInterval(t *testing.T) {
+	t.Run("default when empty", func(t *testing.T) {
+		d, err := resolveCheckInterval("")
+		require.NoError(t, err)
+		assert.Equal(t, defaultAuroraCheckInterval, d)
+	})
+	t.Run("parses duration", func(t *testing.T) {
+		d, err := resolveCheckInterval("250ms")
+		require.NoError(t, err)
+		assert.Equal(t, 250*time.Millisecond, d)
+	})
+	t.Run("rejects zero", func(t *testing.T) {
+		_, err := resolveCheckInterval("0s")
+		require.Error(t, err)
+	})
+	t.Run("rejects garbage", func(t *testing.T) {
+		_, err := resolveCheckInterval("not-a-duration")
+		require.Error(t, err)
+	})
+}

--- a/internal/ptosc/executor.go
+++ b/internal/ptosc/executor.go
@@ -2,6 +2,7 @@ package ptosc
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
@@ -28,17 +29,19 @@ type Executor interface {
 }
 
 type PtOscExecutor struct {
-	logger        *logrus.Logger
-	hasError      bool
-	errorMessages []string
-	outputLines   []string
-	outputSummary string
-	mutex         sync.Mutex
+	logger            *logrus.Logger
+	replicaLagFetcher ReplicaLagFetcher
+	hasError          bool
+	errorMessages     []string
+	outputLines       []string
+	outputSummary     string
+	mutex             sync.Mutex
 }
 
-func NewPtOscExecutor(logger *logrus.Logger) *PtOscExecutor {
+func NewPtOscExecutor(logger *logrus.Logger, replicaLagFetcher ReplicaLagFetcher) *PtOscExecutor {
 	return &PtOscExecutor{
-		logger: logger,
+		logger:            logger,
+		replicaLagFetcher: replicaLagFetcher,
 	}
 }
 
@@ -50,7 +53,15 @@ func (e *PtOscExecutor) ExecuteAlter(tableName, alterStatement string, ptOscConf
 	e.outputSummary = ""
 	e.mutex.Unlock()
 
-	args, password, err := e.BuildArgsWithPassword(tableName, alterStatement, ptOscConfig, dsn, forceDryRun)
+	monitor, monitorCancel, err := e.startAuroraMonitorIfEnabled(ptOscConfig, forceDryRun)
+	if err != nil {
+		return err
+	}
+	if monitorCancel != nil {
+		defer monitorCancel()
+	}
+
+	args, password, err := e.buildArgsWithMonitor(tableName, alterStatement, ptOscConfig, dsn, forceDryRun, monitor)
 	if err != nil {
 		return fmt.Errorf("failed to build pt-osc arguments: %w", err)
 	}
@@ -225,6 +236,16 @@ func (e *PtOscExecutor) BuildArgsWithPassword(
 	rawDSN string,
 	forceDryRun bool,
 ) ([]string, string, error) {
+	return e.buildArgsWithMonitor(tableName, alterStatement, ptOscConfig, rawDSN, forceDryRun, nil)
+}
+
+func (e *PtOscExecutor) buildArgsWithMonitor(
+	tableName, alterStatement string,
+	ptOscConfig config.PtOscConfig,
+	rawDSN string,
+	forceDryRun bool,
+	monitor *AuroraMonitor,
+) ([]string, string, error) {
 	host, port, database, user, password, err := e.ParseDSN(rawDSN)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to parse DSN: %w", err)
@@ -292,6 +313,10 @@ func (e *PtOscExecutor) BuildArgsWithPassword(
 		args = append(args, "--no-check-alter")
 	}
 
+	if monitor != nil {
+		args = append(args, fmt.Sprintf("--pause-file=%s", monitor.PauseFilePath()))
+	}
+
 	if forceDryRun || ptOscConfig.DryRun {
 		args = append(args, "--dry-run")
 	} else {
@@ -301,6 +326,34 @@ func (e *PtOscExecutor) BuildArgsWithPassword(
 	args = append(args, ptOscDSN)
 
 	return args, password, nil
+}
+
+func (e *PtOscExecutor) startAuroraMonitorIfEnabled(
+	ptOscConfig config.PtOscConfig,
+	forceDryRun bool,
+) (*AuroraMonitor, context.CancelFunc, error) {
+	if forceDryRun || ptOscConfig.DryRun {
+		return nil, nil, nil
+	}
+	if !ptOscConfig.AuroraReplicaCheck.Enabled {
+		return nil, nil, nil
+	}
+	if e.replicaLagFetcher == nil {
+		return nil, nil, fmt.Errorf("aurora replica check is enabled but replica lag fetcher is not configured")
+	}
+
+	monitor, err := NewAuroraMonitor(ptOscConfig.AuroraReplicaCheck, e.replicaLagFetcher, e.logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := monitor.Preflight(); err != nil {
+		return nil, nil, fmt.Errorf("aurora replica check preflight failed: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go monitor.Run(ctx)
+	return monitor, cancel, nil
 }
 
 func (e *PtOscExecutor) ParseDSN(dsn string) (host, port, database, user, password string, err error) {

--- a/internal/ptosc/executor_test.go
+++ b/internal/ptosc/executor_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestBuildArgsWithPassword(t *testing.T) {
 	logger := logrus.New()
-	executor := NewPtOscExecutor(logger)
+	executor := NewPtOscExecutor(logger, nil)
 
 	tests := []struct {
 		name             string
@@ -248,9 +248,45 @@ func TestBuildArgsWithPassword(t *testing.T) {
 	}
 }
 
+func TestBuildArgsWithAuroraMonitor(t *testing.T) {
+	logger := logrus.New()
+	executor := NewPtOscExecutor(logger, nil)
+
+	monitor := &AuroraMonitor{pauseFilePath: "/tmp/test-pause"}
+
+	args, password, err := executor.buildArgsWithMonitor(
+		"users",
+		"ADD COLUMN foo INT",
+		config.PtOscConfig{},
+		"user:pass@tcp(localhost:3306)/testdb",
+		false,
+		monitor,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "pass", password)
+	assert.Contains(t, args, "--pause-file=/tmp/test-pause")
+}
+
+func TestBuildArgsWithoutMonitorOmitsPauseFile(t *testing.T) {
+	logger := logrus.New()
+	executor := NewPtOscExecutor(logger, nil)
+
+	args, _, err := executor.BuildArgsWithPassword(
+		"users",
+		"ADD COLUMN foo INT",
+		config.PtOscConfig{},
+		"user:pass@tcp(localhost:3306)/testdb",
+		false,
+	)
+	require.NoError(t, err)
+	for _, a := range args {
+		assert.NotContains(t, a, "--pause-file")
+	}
+}
+
 func TestContainsErrorPattern(t *testing.T) {
 	logger := logrus.New()
-	executor := NewPtOscExecutor(logger)
+	executor := NewPtOscExecutor(logger, nil)
 
 	tests := []struct {
 		name     string
@@ -379,7 +415,7 @@ func TestContainsErrorPattern(t *testing.T) {
 
 func TestParseDSN(t *testing.T) {
 	logger := logrus.New()
-	executor := NewPtOscExecutor(logger)
+	executor := NewPtOscExecutor(logger, nil)
 
 	tests := []struct {
 		name             string

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -85,6 +85,11 @@ func (m *MockDBClient) GetTableBufferPoolSizeMB(schemaName, tableName string) (f
 	return args.Get(0).(float64), args.Error(1)
 }
 
+func (m *MockDBClient) GetMaxAuroraReplicaLagMs() (float64, error) {
+	args := m.Called()
+	return args.Get(0).(float64), args.Error(1)
+}
+
 func (m *MockDBClient) Close() error {
 	args := m.Called()
 	return args.Error(0)


### PR DESCRIPTION
## Summary
- Aurora MySQL では `recursion_method=hosts/dsn` などの既存遅延検出が機能しないため、`information_schema.REPLICA_HOST_STATUS` を定期ポーリングしてレプリカ遅延を監視する仕組みを追加。
- 閾値超で pt-osc に渡した `--pause-file` を作成して一時停止、遅延が回復したら自動で削除する。
- 起動時に pause-file の書き込み可否と `REPLICA_HOST_STATUS` の読み取り可否を事前確認し、いずれかに失敗すれば pt-osc を実行せずに停止する。

## 設定例

```yaml
pt_osc:
  aurora_replica_check:
    enabled: true
    max_lag_ms: 1000
    check_interval: 5s
    pause_file_path: /tmp/alterguard-ptosc-pause
```

デフォルトは `enabled: false` で従来動作と互換。

## 必要権限

### MySQL 権限
DSN ユーザーが `information_schema.REPLICA_HOST_STATUS` を SELECT できる必要があります。Aurora ではこの view は標準で `information_schema` の `SELECT` 権限により公開されているため、明示的に閉じていなければ追加付与は不要です。閉じている場合は以下を付与してください。

```sql
GRANT SELECT ON `information_schema`.* TO 'alterguard'@'%';
```

なお、pt-osc 本体が要求する既存権限 (`ALTER`/`CREATE`/`DROP`/`INSERT`/`UPDATE`/`DELETE`/`INDEX`/`LOCK TABLES`/`TRIGGER`/`PROCESS`/`REPLICATION CLIENT`) は変更ありません。

### OS 権限
alterguard プロセスが `pause_file_path` で指定したパスにファイルを作成・削除できる必要があります。デフォルトの `/tmp/alterguard-ptosc-pause` はほとんどの環境でそのまま使えますが、Kubernetes 環境で root 以外のユーザーで動かす場合は書き込めることを確認してください。

## CI への影響

`information_schema.REPLICA_HOST_STATUS` は Aurora 固有のため通常 MySQL には存在しませんが、

- ユニットテストは `fakeFetcher` でこのアクセスを差し替えているので、Aurora 不在の CI でもグリーンになる
- `aurora_replica_check.enabled` のデフォルトは `false` なので、Aurora 非対応の MySQL でもこのフィーチャを有効化しなければ呼ばれない

ため、既存 CI / `docker-compose` 環境への影響はありません。

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...` (172 tests pass)
- [x] `golangci-lint run ./...` (no issues)
- [ ] Aurora 環境で手動動作確認 (レプリカ遅延を意図的に発生させて pause-file が作成/削除されることを確認)

---
🤖 このPRはAIによって作成されました