### PR TITLE
fix: バッファプールサイズ超過時にSlack通知を送るよう修正

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -639,6 +639,15 @@ func (m *Manager) CleanupOldTable(tableName string) error {
 					"buffer pool size (%.2f MB) exceeds threshold (%.2f MB) for table %s",
 					bufferPoolSizeMB, m.config.Common.BufferPoolSizeThresholdMB, oldTableName)
 				m.logger.Errorf("Buffer pool size check failed: %s", errMsg)
+
+				taskName := "cleanup"
+				if m.dryRun {
+					taskName = "cleanup (DRY RUN)"
+				}
+				if slackErr := m.slack.NotifyWarning(taskName, tableName, errMsg); slackErr != nil {
+					m.logger.Errorf("Failed to send buffer pool size check warning notification: %v", slackErr)
+				}
+
 				return fmt.Errorf("buffer pool size check failed: %s", errMsg)
 			}
 		}

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -849,7 +849,9 @@ func TestCleanupTable(t *testing.T) {
 				mockDB.On("GetTableBufferPoolSizeMB", "testdb", "test_table_old").Return(tt.bufferPoolSizeMB, tt.bufferPoolError)
 			}
 
-			if !tt.expectBufferPoolCheckFailed {
+			if tt.expectBufferPoolCheckFailed {
+				mockSlack.On("NotifyWarning", taskName, tt.tableName, mock.Anything).Return(nil)
+			} else {
 				mockSlack.On("NotifyStartWithQuery", taskName, tt.tableName, expectedQuery, int64(0)).Return(nil)
 				mockSlack.On("NotifySuccessWithQuery", taskName, tt.tableName, expectedQuery, int64(0), mock.Anything).Return(nil)
 


### PR DESCRIPTION
CleanupOldTableでバッファプールサイズが閾値を超えた場合、通知フローに入る前にreturnしてしまい、Slack通知が送られていなかった。